### PR TITLE
Fully Implement Support for the Asserted 'CHKCONFIG_OPTION_USE_DEFAULT_DIRECTORY' Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ checking the build results is recommended:
 In addition to depending on the C Standard Library, chkconfig depends
 on:
 
-  * nlassert
-  * nlunit-test
+  * [nlassert](https://github.com/Nuovations/nlassert)
+  * [nlunit-test](https://github.com/Nuovations/nlunit-test)
 
 However, nlunit-test is only required when building and running the chkconfig
 unit test suite.

--- a/src/chkconfig/chkconfig-main.cpp
+++ b/src/chkconfig/chkconfig-main.cpp
@@ -529,9 +529,9 @@ static chkconfig_status_t ListAllFlags(chkconfig_context_t &inContext)
     chkconfig_status_t                   lStatus;
     chkconfig_status_t                   lRetval  = CHKCONFIG_STATUS_SUCCESS;
 
-    lRetval = chkconfig_state_get_all(&inContext,
-                                      &lFlagStateTuples,
-                                      &lFlagStateTuplesCount);
+    lRetval = chkconfig_state_copy_all(&inContext,
+                                       &lFlagStateTuples,
+                                       &lFlagStateTuplesCount);
     nlREQUIRE_SUCCESS(lRetval, done);
 
     // Sort the flags according to the command line options

--- a/src/lib/chkconfig.cpp
+++ b/src/lib/chkconfig.cpp
@@ -722,9 +722,9 @@ static chkconfig_status_t chkconfigStateGetAll(const char *inDirectoryPath,
     return (lRetval);
 }
 
-static chkconfig_status_t chkconfigStateGetAll(const char *inDirectoryPath,
-                                               chkconfig_flag_state_tuple_t *&outFlagStateTuples,
-                                               size_t &outCount)
+static chkconfig_status_t chkconfigStateCopyAll(const char *inDirectoryPath,
+                                                chkconfig_flag_state_tuple_t *&outFlagStateTuples,
+                                                size_t &outCount)
 {
     size_t                         lCount           = 0;
     chkconfig_flag_state_tuple_t * lFlagStateTuples = nullptr;
@@ -774,15 +774,15 @@ static chkconfig_status_t chkconfigStateGetAll(const char *inDirectoryPath,
     return (lRetval);
 }
 
-static chkconfig_status_t chkconfigStateGetAll(chkconfig_context_t &inContext,
-                                               chkconfig_flag_state_tuple_t *&outFlagStateTuples,
-                                               size_t &outCount)
+static chkconfig_status_t chkconfigStateCopyAll(chkconfig_context_t &inContext,
+                                                chkconfig_flag_state_tuple_t *&outFlagStateTuples,
+                                                size_t &outCount)
 {
     chkconfig_status_t             lRetval = CHKCONFIG_STATUS_SUCCESS;
 
-    lRetval = chkconfigStateGetAll(inContext.m_options->m_state_dir,
-                                   outFlagStateTuples,
-                                   outCount);
+    lRetval = chkconfigStateCopyAll(inContext.m_options->m_state_dir,
+                                    outFlagStateTuples,
+                                    outCount);
     nlREQUIRE_SUCCESS(lRetval, done);
 
  done:
@@ -1113,7 +1113,7 @@ chkconfig_status_t chkconfig_options_set(chkconfig_context_pointer_t context_poi
  *
  *  @sa chkconfig_state_get_count
  *  @sa chkconfig_state_get_multiple
- *  @sa chkconfig_state_get_all
+ *  @sa chkconfig_state_copy_all
  *
  *  @ingroup observers
  *
@@ -1163,7 +1163,7 @@ chkconfig_status_t chkconfig_state_get(chkconfig_context_pointer_t context_point
  *
  *  @sa chkconfig_state_get_count
  *  @sa chkconfig_state_get
- *  @sa chkconfig_state_get_all
+ *  @sa chkconfig_state_copy_all
  *  @sa chkconfig_flag_state_tuple_init
  *
  *  @ingroup observers
@@ -1211,7 +1211,7 @@ chkconfig_status_t chkconfig_state_get_multiple(chkconfig_context_pointer_t cont
  *
  *  @sa chkconfig_state_get_count
  *  @sa chkconfig_state_get
- *  @sa chkconfig_state_get_all
+ *  @sa chkconfig_state_copy_all
  *  @sa chkconfig_flag_state_tuple_init
  *
  *  @ingroup observers
@@ -1234,10 +1234,10 @@ chkconfig_status_t chkconfig_state_get_count(chkconfig_context_pointer_t context
 
 /**
  *  @brief
- *    Get the state values associated with all flags covered by a
+ *    Copy the state values associated with all flags covered by a
  *    backing store file.
  *
- *  This attempts to get the state values associated with all flags
+ *  This attempts to copy the state values associated with all flags
  *  covered by a backing store file.
  *
  *  @note
@@ -1247,7 +1247,7 @@ chkconfig_status_t chkconfig_state_get_count(chkconfig_context_pointer_t context
  *
  *  @param[in]      context_pointer    A pointer to the chkconfig
  *                                     library context for which to
- *                                     get the state values for all
+ *                                     copy the state values for all
  *                                     flags covered by a backing
  *                                     store file.
  *  @param[in,out]  flag_state_tuples  A pointer to storage for a
@@ -1272,15 +1272,15 @@ chkconfig_status_t chkconfig_state_get_count(chkconfig_context_pointer_t context
  *
  *  @sa chkconfig_state_get_count
  *  @sa chkconfig_state_get
- *  @sa chkconfig_state_get_all
+ *  @sa chkconfig_state_get_multiple
  *  @sa chkconfig_flag_state_tuple_init
  *
  *  @ingroup observers
  *
  */
-chkconfig_status_t chkconfig_state_get_all(chkconfig_context_pointer_t context_pointer,
-                                           chkconfig_flag_state_tuple_t **flag_state_tuples,
-                                           size_t *count)
+chkconfig_status_t chkconfig_state_copy_all(chkconfig_context_pointer_t context_pointer,
+                                            chkconfig_flag_state_tuple_t **flag_state_tuples,
+                                            size_t *count)
 {
     chkconfig_status_t retval = CHKCONFIG_STATUS_SUCCESS;
 
@@ -1288,9 +1288,9 @@ chkconfig_status_t chkconfig_state_get_all(chkconfig_context_pointer_t context_p
     nlREQUIRE_ACTION(flag_state_tuples != nullptr, done, retval = -EINVAL);
     nlREQUIRE_ACTION(count             != nullptr, done, retval = -EINVAL);
 
-    retval = Detail::chkconfigStateGetAll(*context_pointer,
-                                          *flag_state_tuples,
-                                          *count);
+    retval = Detail::chkconfigStateCopyAll(*context_pointer,
+                                           *flag_state_tuples,
+                                           *count);
 
  done:
     return (retval);

--- a/src/lib/chkconfig.cpp
+++ b/src/lib/chkconfig.cpp
@@ -493,12 +493,19 @@ static chkconfig_status_t chkconfigStatePathCopy(const chkconfig_context_t &inCo
     return (lRetval);
 }
 
+static bool chkconfigUseDefaultDirectory(const chkconfig_context_t &inContext)
+{
+    const bool lRetval = (inContext.m_options->m_use_default_dir &&
+                          (inContext.m_options->m_default_dir != nullptr));
+
+    return (lRetval);
+}
+
 static chkconfig_status_t chkconfigStateGet(chkconfig_context_t &inContext,
                                             const chkconfig_flag_t &inFlag,
                                             chkconfig_state_t &outState)
 {
-    const bool         lUseDefaultDirectory = (inContext.m_options->m_use_default_dir &&
-                                               (inContext.m_options->m_default_dir != nullptr));
+    const bool         lUseDefaultDirectory = chkconfigUseDefaultDirectory(inContext);
     char               lFlagPath[PATH_MAX];
     chkconfig_status_t lRetval = CHKCONFIG_STATUS_SUCCESS;
 

--- a/src/lib/chkconfig.cpp
+++ b/src/lib/chkconfig.cpp
@@ -1181,7 +1181,7 @@ static chkconfig_status_t chkconfigStateCopyAllWithDefaultDirectory(chkconfig_co
     lRetval = chkconfigFlagStateTupleCopyUnion(lStateFlagStateTuples,
                                                lStateCount,
                                                lDefaultFlagStateTuples,
-                                               lDefaultCount,                                              
+                                               lDefaultCount,
                                                lUnionFlagStateTuples,
                                                lUnionCount);
     nlREQUIRE_SUCCESS(lRetval, done);

--- a/src/lib/chkconfig.h
+++ b/src/lib/chkconfig.h
@@ -285,9 +285,9 @@ extern chkconfig_status_t chkconfig_state_get_multiple(chkconfig_context_pointer
                                                        size_t count);
 extern chkconfig_status_t chkconfig_state_get_count(chkconfig_context_pointer_t context_pointer,
                                                     size_t *count);
-extern chkconfig_status_t chkconfig_state_get_all(chkconfig_context_pointer_t context_pointer,
-                                                  chkconfig_flag_state_tuple_t **flag_state_tuples,
-                                                  size_t *count);
+extern chkconfig_status_t chkconfig_state_copy_all(chkconfig_context_pointer_t context_pointer,
+                                                   chkconfig_flag_state_tuple_t **flag_state_tuples,
+                                                   size_t *count);
 
 // MARK: Mutators
 


### PR DESCRIPTION
This fully-implements support for the asserted `CHKCONFIG_OPTION_USE_DEFAULT_DIRECTORY` option for the `chkconfig_state_copy_all` and ``chkconfig_state_get_count` interfaces.
